### PR TITLE
Remove using namespace std; from header

### DIFF
--- a/Hungarian.cpp
+++ b/Hungarian.cpp
@@ -14,6 +14,7 @@
 #include <cmath>  // for fabs()
 #include "Hungarian.h"
 
+using namespace std;
 
 HungarianAlgorithm::HungarianAlgorithm(){}
 HungarianAlgorithm::~HungarianAlgorithm(){}

--- a/Hungarian.h
+++ b/Hungarian.h
@@ -15,7 +15,6 @@
 #include <iostream>
 #include <vector>
 
-using namespace std;
 
 
 class HungarianAlgorithm
@@ -23,7 +22,7 @@ class HungarianAlgorithm
 public:
 	HungarianAlgorithm();
 	~HungarianAlgorithm();
-	double Solve(vector <vector<double> >& DistMatrix, vector<int>& Assignment);
+	double Solve(std::vector <std::vector<double> >& DistMatrix, std::vector<int>& Assignment);
 
 private:
 	void assignmentoptimal(int *assignment, double *cost, double *distMatrix, int nOfRows, int nOfColumns);

--- a/testMain.cpp
+++ b/testMain.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 #include "Hungarian.h"
-
+using namespace std;
 
 int main(void)
 {


### PR DESCRIPTION
Merging #https://github.com/mcximing/hungarian-algorithm-cpp/pull/7 into fork
comments from above pr
An obvious clean-up but also fix to avoid Windows API ambiguities (e.g. byte vs std::byte)